### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/nginx/nginx_prod/Dockerfile
+++ b/nginx/nginx_prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:v0.9.0
 
 RUN rm /etc/nginx/nginx.conf
 


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`